### PR TITLE
Fix dev channel dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.4
 author: Clovis Nicolas <clovisnicolas0@gmail.com>
 homepage: https://github.com/clovisnicolas/flutter_screen
 
-#environment:
-#  sdk: '>=2.0.0 <3.0.0'
+environment:
+  sdk: '>=2.0.0-dev.28.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.4
 author: Clovis Nicolas <clovisnicolas0@gmail.com>
 homepage: https://github.com/clovisnicolas/flutter_screen
 
-environment:
-  sdk: '>=2.0.0 <3.0.0'
+#environment:
+#  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hi @clovisnicolas currently your plugin is requiring any user to change it's sdk channel from beta (standard) to dev, which people might not want to do.
So I request that you pull this diff in, to make screen's users life easier, without any side-effect.

Thanks,
Regards