### PR TITLE
fix compile error under Android 3.3 and Flutter 1.1.9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,14 +26,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
-        versionCode 1
-        versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
there is some android sdk version complain when compile with android 3.3 and flutter 1.1.9 , this commit fixed the error when compile with latest flutter and android studio 3.3