### PR TITLE
Remove `System.out` logging

### DIFF
--- a/android/src/main/java/flutter/plugins/screen/screen/ScreenPlugin.java
+++ b/android/src/main/java/flutter/plugins/screen/screen/ScreenPlugin.java
@@ -43,14 +43,8 @@ public class ScreenPlugin implements MethodCallHandler {
         break;
       case "keepOn":
         Boolean on = call.argument("on");
-        if (on) {
-          System.out.println("Keeping screen on ");
-          _registrar.activity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        }
-        else{
-          System.out.println("Not keeping screen on");
-          _registrar.activity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-        }
+        if (on) _registrar.activity().getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        else _registrar.activity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         result.success(null);
         break;
 


### PR DESCRIPTION
Logging this way is quite a bad practice.  
If you really want to have logs, you could think abou logging differently or you might want to use something like a callback, stream or listenable on the Dart side.