### PR TITLE
Add caveat in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Make sure you add the following permissions to your Android Manifest
 <uses-permission android:name="android.permission.WAKE_LOCK" />
 ```
 
+## Caveats
+
+Changing brightness sets the screen brightness for the current app only (on modern Android versions) and it also locks the brightness slider. See https://developer.android.com/reference/android/view/WindowManager.LayoutParams#screenBrightness for API details.
+
 ## Example
 ``` dart
 // Import package


### PR DESCRIPTION
Using this on Android 10 I get the screen brightness changed, but the brightness control is also locked from making other changes (the effect is as described in https://support.google.com/android/thread/43144590?hl=en ). I found some more info in https://stackoverflow.com/questions/4544967/get-preferred-screen-brightness-in-android and I know that apps for blue light filtering or automatic night time dimming use GPU-related screen filtering rather than touching the screen brightness setting.
It seems the WRITE_SETTINGS permission could theoretically allow changing the system-wide setting, but I've not seen this work in practice on Android 10.